### PR TITLE
Update instructions about the classifier service

### DIFF
--- a/basic_examples/natural_language_classifier/README.md
+++ b/basic_examples/natural_language_classifier/README.md
@@ -1,179 +1,195 @@
 #Natural Language Classifier
-**Note** For this exercise please check that your Bluemix region is set to **_US South_**
 
-The Natural Language Classifier (NLC) is a service that can be trained and it 
-is useful to describe how to create the steps to use it since it offers some cognitive learning features. 
+**Note:** For this exercise, make sure that your Bluemix region is set to **_US South_**
 
-Overview of NLC -> [Overview](http://www.ibm.com/smarterplanet/us/en/ibmwatson/developercloud/doc/nl-classifier/)
- 
-Standard NLC Demo -> [Demo](http://natural-language-classifier-demo.mybluemix.net)
+The Natural Language Classifier is a service that needs to be trained. Take a look at the documentation and demo for the service to learn about it:
 
- Very useful API documentation which is sometimes hard to find -> [Useful API docs for curl, Node and Java](https://www.ibm.com/smarterplanet/us/en/ibmwatson/developercloud/natural-language-classifier/api/v1/?node#introduction)
+- [Overview](http://www.ibm.com/watson/developercloud/doc/natural-language-classifier/index.html) of the Natural Language Classifier service.
+- [Demo](http://natural-language-classifier-demo.mybluemix.net) of the service.
+- [API reference](http://www.ibm.com/watson/developercloud/natural-language-classifier/api/v1/?node#introduction), which includes helpful information about curl and the SDKs.
 
-##Creating and populating a NLC Service on Bluemix
+##Creating and populating the service on Bluemix
+Create an unbound instance of the service in Bluemix.
 
-Within Bluemix you can create an **unbound instance** of the NLC Service, by selecting Natural Language Classifier
-in the Bluemix catalog.
+Select **Natural Language Classifier** in the Bluemix catalog.
+
+Click **Create** to instantiate your instance of the service:
 
 ![ScreenShot](images/nlc_std_service.png)
 
-Click on the CREATE button to instantiate your unbound instance of the Natural Language Classifier service.
-
-On the service description page click on the "Access the toolkit" button. 
+On the service dashboard, click **Access the beta toolkit**.
 ![ScreenShot](images/nlc_access_toolkit.png)
 
-Sign on to Bluemix to allow the toolkit to access your instance of the Natural Language Classifier.
+Log in to Bluemix to load your instance of the Natural Language Classifier.
 ![ScreenShot](images/nlc_toolkit_signon.png)
 
-Confirm authorization for the toolkit access your instance.
+Confirm that you allow the toolkit to access your instance:
 ![ScreenShot](images/nlc_toolkit_authorize.png)
 
-Click on Training and then follow the steps as documented in [NLC toolkit](https://www.ibm.com/smarterplanet/us/en/ibmwatson/developercloud/doc/nl-classifier/tool_examples.shtml).  
+Click **Training**, and then follow the steps as documented in the [documentation](http://www.ibm.com/watson/developercloud/doc/natural-language-classifier/tool-overview.html).
 
-Train the NLC Service with the sample CSV file.
+Train the Natural Language Classifier service with the sample CSV file:
 
 ![ScreenShot](images/nlc_toolkit_training.png)
 
-You will need a Classifier ID, this can be obtained by clicking the Classifiers button and the Classifier ID is shown.
+You need a Classifier ID, which you can find by clicking **Classifiers**:
 
 ![ScreenShot](images/nlc_classifier_id.png)
 
-The flows for this part of the lab are here -> [flows](nlc_flows.json)
+##Connecting to an existing service on Bluemix
 
-##Connecting to an existing NLC Service on Bluemix
- 
-In this lab we will assume (for now) that you have created a NLC Service in Bluemix and now wish to:
-1. check it's status and 
-2. ask it a question via calls in Node-RED. 
-We also assume you have created a Node-RED application using the Node-RED Starter Community boilerplate in Bluemix.
+**Tip:** You can download the [flows](nlc_flows.json) for this part of the lab.
 
-Open your Node-RED flow editor, then drag/drop two Inject nodes, two Function nodes, one http request node and one Debug node and join up as shown below :
+In this lab, we assume (for now) that you created an instance of the Natural Language Classifier service in Bluemix. 
+
+We also assume that you created a Node-RED application by using the Node-RED Starter Community boilerplate in Bluemix.
+
+These are your next steps:
+
+- Check the status of the classifier,
+- Ask a question of the service via calls in Node-RED.
+
+Open your Node-RED flow editor, then drag two **Inject** nodes, two **Function** nodes, one **http request** node and one **Debug** node. 
+
+Join them as shown in this image:
  
 ![ScreenShot](images/nlc_nodes_joined.png)
 
-Notice the blue icons next to each node which indicates further configurations are needed on each node.
+Notice the blue icons next to each node that indicate that further configurations are needed on each node.
 
-Double-click the top Inject node, select the string option and leave blank.
+Double-click the top **Inject** node, select the string option, and leave it `blank`:
 
 ![ScreenShot](images/nlc_inject_node.png)
 
-Double-click the top Function node and enter the following code and name the node "get NLC status".  
-
-NOTE : the NLC classifier ID has been hard coded in the request (msg.url="https://gateway.watsonplatform.net/natural-language-classifier/api/v1/classifiers/**_D385B2-nlc-530_**") just for speed - when the official Node-RED NLC nodes are created then there will be some other mechanism (to be decided) on how the NLC classifier ID is used/entered. **_You must replace the D385B2-nlc-530 with your own classifier id_**
+Double-click the top **Function** node:
+- Name the node `get NLC status`.
+- Enter the following code. **Important:** Replace `D385B2-nlc-530` with your classifier ID.
 
     `msg.url="https://gateway.watsonplatform.net/natural-language-classifier/api/v1/classifiers/D385B2-nlc-530";`
 
+The classifier ID is hardcoded in this example request (msg.url="https://gateway.watsonplatform.net/natural-language-classifier/api/v1/classifiers/**_D385B2-nlc-530_**"). When the official Node-RED NLC nodes are created, there will be some other mechanism (to be decided) to enter the classifier ID.
+
 ![ScreenShot](images/nlc_get_status_function.png)
 
-Go to Bluemix and open your application and navigate to the NLC Service.  Go to your NLC Service and click on Show Credentials - you have already carried this out in the section above and is just repeated here for reference.
+Back in Bluemix, open your application and navigate to the Natural Language Classifier service.
 
+Go to your service instance and click **Show Credentials**:
 
 ![ScreenShot](images/nlc_credentials.png)
 
-    {
-      "natural_language_classifier": [
-        {
-          "name": "ibmwatson-nlc-classifier",
-          "label": "natural_language_classifier",
-          "plan": "standard",
-          "credentials": {
-            "url": "https://gateway.watsonplatform.net/natural-language-classifier/api",
-            "username": "306c5772-63d0-40f4-b50d-4de334a00243",
-            "password": "WHAT EVER YOUR PASSWORD IS"
-          }
-        }
-      ]
-    }
+```json
+{
+  "natural_language_classifier": [
+	{
+	  "name": "ibmwatson-nlc-classifier",
+	  "label": "natural_language_classifier",
+	  "plan": "standard",
+	  "credentials": {
+		"url": "https://gateway.watsonplatform.net/natural-language-classifier/api",
+		"username": "306c5772-63d0-40f4-b50d-4de334a00243",
+		"password": "WHAT EVER YOUR PASSWORD IS"
+	  }
+	}
+  ]
+}
+```
 
-Make a note of the username and password values.  Double-click the HTTP Request node and enter your credentials for your NLC Service in the node 
+Copy your username and password values.
+
+Double-click the **http request** node and enter your service credentials for your Natural Language Classifier instance in the node:
 
 ![ScreenShot](images/nlc_credentials_request_node.png)
 
-Click the Deploy button.
+Click **Deploy**.
 
-Click on the Inject node button and see if you are returned in the Debug Tab the reply that the NLC Service is available.
+Click **Inject node** and see if the Natural Language Classifier service is available in the "debug" tab:
 
 ![ScreenShot](images/nlc_available.png)
 
-Double-click the other Function node and paste the following code :
+Double-click the other **Function** node and paste the following code. Replace `D385B2-nlc-530` with your classifier ID:
 
         msg.url="https://gateway.watsonplatform.net/natural-language-classifier/api/v1/classifiers/D385B2-nlc-530/classify?text=" + encodeURI(msg.payload);
     
 ![ScreenShot](images/nlc_ask_question.png)
 
-Double-click the second Inject node and change the payload to String and enter the question "Is it hot ?"
+Double-click the second **Inject** node. Change the payload to `string` and enter the question, `Is it hot?`:
 
 ![ScreenShot](images/nlc_inject_ask.png)
 
-Click the Deploy button
+Click  **Deploy**
 
-Click the button of the Inject node and look at the contents of the Debug Tab
+Click the button of the **Inject** node and look at the contents of the "debug" tab:
 
 ![ScreenShot](images/nlc_debug_ask_output.png)
 
-##Using the NLC Service from Node-RED
+##Using Natural Language Classifier from Node-RED
 
-Using your existing boilerplate, drag a Natural Language Classifier (NLC) node to the palette.  Double click and set the Mode to **Training** and give it a name.
+Using your existing boilerplate, drag a **Natural Language Classifier (NLC)** node to the palette. 
+
+Double click and set the **Mode** to `train`, and give it a name:
 
 ![ScreenShot](images/nlc_edit_training.png)
 
-We assume that you have enabled your Application to have the both the Dropbox and Box Node-RED nodes added to your Application - if you haven't then see -> [Dropbox nodes](https://github.com/watson-developer-cloud/node-red-labs/tree/master/utilities/dropbox_setup).  Make sure you have uploaded file weather_data_train.csv to your Dropbox or Box locations (copy of the file is here -> [weather csv file](weather_data_train.csv)).
+Make sure that you have both the **Dropbox** and **Box** Node-RED nodes added to your application. If you haven't, see -> [Dropbox nodes](https://github.com/watson-developer-cloud/node-red-labs/tree/master/utilities/dropbox_setup).
 
-Add the right Dropbox node to the palette
+Make sure that you uploaded file weather_data_train.csv to your Dropbox or Box locations (a copy of the file is here -> [weather csv file](weather_data_train.csv)).
+
+Add the right **Dropbox** node to the palette:
 
 ![ScreenShot](images/nlc_dropbox_node.png)
 
-Add your Dropbox node credentials and click Add
+Add your **Dropbox** node credentials and click **Add**:
 
 ![ScreenShot](images/nlc_dropbox_setup.png)
 
-Add the weather_data_train.csv file to the Dropbox node settings
+Add the weather_data_train.csv file to the Dropbox node settings:
 
 ![ScreenShot](images/nlc_dropbox_filename.png)
 
-Join this to the NLC node and also introduce a Inject node to thus be able to start Dropbox to get the file and feed it into the NLC node, also add a Debug node to the output of the NLC node
+Join this to the **NLC** node, and also introduce an **Inject** node. This flow gets the file from Dropbox and feeds it into the NLC node.
+
+Also add a **Debug** node to the output of the NLC node:
 
 ![ScreenShot](images/nlc_nlc_flow_inject_debug.png)
 
-The ID of the NLC is returned in the Debug Tab of Node-RED - in the example below this is **cd6374x52-nlc-1515**
+The ID of the classifier is returned in the "debug" tab of Node-RED. In the following example the ID is **cd6374x52-nlc-1515**:
 
 ![ScreenShot](images/nlc_debug_tab_nlc_id.png)
 
-NOTE : the NLC is now being trained - this could take some time (30-50 mins).  There is currently (April 2016) no method of being able to know when the training is finished.  Some loop code can been written in Node-RED which poles the NLC Service to determine when the service has completed the training and is in Available mode but this is not part of this lab.
+**Tip:** The classifier is now being trained, which can take some time (30-50 mins). There is currently (April 2016) no way to know when the training is finished.  Some loop code can been written in Node-RED which polls the service to determine when the service is available, but this is not part of this lab.
 
-To see the status of the training then go to the NLC Service of your App and click on the Service
+To see the status of the training, go to the Natural Language Classifier service of your app and click the service:
 
 ![ScreenShot](images/nlc_status.png)
 
-You should be presented with a page which has a "Access beta toolkit" button
+You should be presented with a page with the **Access beta toolkit** button:
 
 ![ScreenShot](images/nlc_access_beta_toolkit.png)
 
-Click the button and you should see a list of NLC classifiers which are in Training or Available mode (you will need to click the Sign In button so the Toolkit can access your NLC classifiers).  Note down one of the Classifier IDs since you will test the deletion functionality later on in this Lab.
+Click **Access beta toolkit**. You should see a list of classifiers that have a status of `Training` or `Available`. You need to be signed in so the Toolkit can access your classifiers.
+
+Copy a classifier ID so that you can test the deletion functionality later on in this lab:
 
 ![ScreenShot](images/nlc_access_beta_toolkit_list.png)
 
-Add 4 Inject nodes, 3 Classifier nodes and 3 debug nodes as shown below:
+Add 4 Inject nodes, 3 Classifier nodes and 3 debug nodes:
 
 ![ScreenShot](images/nlc_all_flows.png)
 
-Change the first new Classifier node to List in the dropdown.
+Change the **Mode ** of the first new classifier node to `List`:
 
 ![ScreenShot](images/nlc_dropdown_list.png)
 
-Change the next classifier node to Classify and the final one to Remove. 
-**NOTE : For the Remove Inject node you must change the Inject string to a Classifier that exists (you noted one down earlier).**
+Change the next classifier node to `Classify` and the final one to `Remove`.
 
-Click on the Get List Inject node - in the Debug Tab you will see a list of possible classifiers.
+**NOTE**: For the **Remove Inject** node, change the **Inject** string to a classifier that exists (you noted one down earlier).
+
+Click the **Get List Inject** node. In the "debug" tab you see a list of classifiers.
 
 ![ScreenShot](images/nlc_list.png)
 
-Click on the "Is it hot?" node - in the Debug Tab you will see (as before) the confidence level that the NLC classifier returns
+Click the **Is it hot?** node. In the "debug" tab, you see (as before) the confidence level that the classifier returns.
 
-Click on the Inject node connected to the Remove NLC node - **be careful** - when clicked it will delete the classifier.
+Click the **Inject** node connected to the **Remove NLC** node.  **Important:** when clicked it will delete the classifier.
 
-
-The flows for this part of the lab are here -> [flows](nlc_flows_with_nlc_service.json)
-
-
-
+Download the completed [flows](nlc_flows_with_nlc_service.json) to compare against what you created.


### PR DESCRIPTION

- NLC is now in Markdown, so links have changed.
- Also removed old smarterplanet links
- Also updated the style, grammar, terminology, and tagging to match closer to what we do in the docs.